### PR TITLE
Fixing DEPRECATION WARNING

### DIFF
--- a/tasks/configure-Debian.yml
+++ b/tasks/configure-Debian.yml
@@ -30,7 +30,7 @@
 
 - name: Add htpasswd configuration.
   htpasswd: path={{ item.file }} name={{ item.username }} password={{ item.password }} state=present
-  with_items: apache_htpasswd
+  with_items: "{{ apache_htpasswd }}"
   when: apache_htpasswd
 
 - name: Add apache vhosts configuration.


### PR DESCRIPTION
TASK [rade333.apache : Add htpasswd configuration.] ****************************
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your
playbooks so that the environment value uses the full variable syntax
('{{apache_htpasswd}}').
This feature will be removed in a future release.
Deprecation warnings can be disabled by setting deprecation_warnings=False in
ansible.cfg.
